### PR TITLE
Allow kwallet6 dbus access

### DIFF
--- a/com.vivaldi.Vivaldi.yaml
+++ b/com.vivaldi.Vivaldi.yaml
@@ -41,7 +41,8 @@ finish-args:
   - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.SessionManager
-  - --talk-name=org.kde.kwalletd5 # Used for password encryption under KDE environments
+  - --talk-name=org.kde.kwalletd5 # Used for password encryption under KDE5 environments
+  - --talk-name=org.kde.kwalletd6 # Used for password encryption under KDE6 environments
 
 modules:
   - name: dconf


### PR DESCRIPTION
With the launch of KDE6, there's new kwallet version as well. Chromium already supports it, but vivaldi in flatpak is not allowed to talk to it.

This change simply allows talking to `org.kde.kwalletd6` in the same way it currently allows `org.kde.kwalletd5`.

Without this, people upgrading from KDE5 to KDE6 will loose all saved passwords and even newly saved passwords are not persisted.